### PR TITLE
Issue #18958 remove hard-coded /wp-content

### DIFF
--- a/includes/class-wc-product-download.php
+++ b/includes/class-wc-product-download.php
@@ -96,7 +96,7 @@ class WC_Product_Download implements ArrayAccess {
 		$file_url = $this->get_file();
 		if ( '..' === substr( $file_url, 0, 2 ) || '/' !== substr( $file_url, 0, 1 ) ) {
 			$file_url = realpath( ABSPATH . $file_url );
-		} elseif ( '/wp-content' === substr( $file_url, 0, 11 ) ) {
+		} elseif ( CONTENT_DIR === substr( $file_url, 0, 11 ) ) {
 			$file_url = realpath( WP_CONTENT_DIR . substr( $file_url, 11 ) );
 		}
 		return apply_filters( 'woocommerce_downloadable_file_exists', file_exists( $file_url ), $this->get_file() );


### PR DESCRIPTION
When you're checking if a file exists you should be using the CONTENT_DIR constant rather than hard coding "/wp-content"
This fixes that